### PR TITLE
Add .gitignore file for Python development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+
+# Virtual environment
+venv/
+env/
+ENV/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+coverage.xml
+*.cover
+.pytest_cache/
+
+# Logs
+*.log
+
+# Local development settings
+.env
+.env.local
+
+# Project specific
+temp/
+tmp/


### PR DESCRIPTION
Added a comprehensive .gitignore file for Python development to prevent tracking of common temporary and generated files.\n\nChanges:\n- Added rules for Python bytecode (__pycache__, *.pyc)\n- Added rules for virtual environments\n- Added rules for IDE specific files\n- Added rules for test coverage reports\n- Added rules for logs and local development settings\n\nThis will help keep the repository clean and prevent accidental commits of temporary files.